### PR TITLE
Prevent shadowing of commands across tools

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -73,7 +73,7 @@ jobs:
           ${{ matrix.PREFIX }} tox -e ${{ matrix.tox_env }}
 
   publish:
-    name: Publish to PyPI registry
+    name: packaging
     needs:
       - build
     runs-on: ubuntu-20.04

--- a/src/mk/runner.py
+++ b/src/mk/runner.py
@@ -3,21 +3,22 @@ import git
 from pathlib import Path
 import subprocess
 import sys
-from mk.tools import Tool
+from mk.tools import Tool, Action
+from typing import List
 
 
 class Runner:
     def __init__(self) -> None:
         self.repo = git.Repo(".", search_parent_directories=True)
         self.root = Path(self.repo.working_dir)
-        self.actions = []
+        self.actions: List[Action] = []
 
         for c in Tool:
             if c.is_present(self.root):
                 logging.info(f"Detected {c} !")
-                self.actions.extend(c().actions())
+                self.actions.extend(c.actions())
             else:
-                logging.debug(f"{c} not detected !")
+                logging.debug("%s not detected !", c)
 
         if self.repo.is_dirty():
             logging.warning(f"Repo is dirty on {self.repo.active_branch}")

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist = lint,py,packaging
-minversion = 3.7
+minversion = 4.0.0a6
 isolated_build = true
-skip_missing_interpreters = true
+skip_missing_interpreters = false
 
 [testenv]
 description = run the tests with pytest under {basepython}
@@ -29,7 +29,6 @@ commands =
     mk --help
 
 [testenv:lint]
-basepython = python3.7
 passenv = {[testenv]passenv}
           # without PROGRAMDATA cloning using git for Windows will fail with an
           # `error setting certificate verify locations` error
@@ -60,4 +59,4 @@ commands =
       --outdir {toxinidir}/dist/ \
       {toxinidir}
     # metadata validation
-    sh -c "python -m twine check .tox/dist/*"
+    python -m twine check {toxinidir}/dist/*


### PR DESCRIPTION
As it may be possible for different tools to provide the same commands, we now add a number when this happens.