### PR TITLE
Add ability to recognize ansible playbooks

### DIFF
--- a/playbooks/example-playbook.yml
+++ b/playbooks/example-playbook.yml
@@ -1,0 +1,1 @@
+- hosts: localhost

--- a/setup.cfg
+++ b/setup.cfg
@@ -57,6 +57,7 @@ where = src
 console_scripts =
     mk=mk.__main__:cli
 mk_tools =
+    ansible=mk.tools.ansible:AnsibleTool
     tox=mk.tools.tox:ToxTool
     npm=mk.tools.npm:NpmTool
     pre-commit=mk.tools.pre_commit:PreCommitTool

--- a/src/mk/tools/__init__.py
+++ b/src/mk/tools/__init__.py
@@ -10,13 +10,16 @@ class Action:
         tool: "Tool",
         description: Optional[str] = None,
         cwd: Optional[str] = None,
+        filename: Optional[str] = None,
         args: Optional[List[Any]] = [],
     ) -> None:
         self.name = name
         self.description: str = (description or "...") + f" (from {tool})"
         self.tool = tool
         self.cwd = cwd
+        self.filename = filename
         self.args = args
+
         # Python does not allow writing __doc__ and this is what click uses
         # for storing command names.
         # self.run.__doc__ = "bleah!"

--- a/src/mk/tools/ansible.py
+++ b/src/mk/tools/ansible.py
@@ -1,0 +1,33 @@
+import glob
+import os
+import subprocess
+from typing import List, Optional
+
+from mk.tools import Action, Tool
+
+
+class AnsibleTool(Tool):
+    name = "ansible"
+
+    def run(self, action: Optional[Action] = None):
+        if action and action.filename:
+            subprocess.run(["ansible-playbook", action.filename], check=True)
+
+    def is_present(self, path: str) -> bool:
+        if os.path.isdir(os.path.join(path, "playbooks")):
+            return True
+        return False
+
+    def actions(self) -> List[Action]:
+        actions: List[Action] = []
+        for filename in glob.glob("playbooks/*.yml"):
+            name = os.path.splitext(os.path.basename(filename))[0]
+            actions.append(
+                Action(
+                    name=name,
+                    description="Run ansible-playbook %s" % filename,
+                    tool=self,
+                    filename=filename,
+                )
+            )
+        return actions


### PR DESCRIPTION
This will expose all playbooks found under `playbooks/*.yml` as commands.

For example, if it finds `playbooks/deploy.yml`, it will add a `deploy` command that runs this playbook.