### PR TITLE
devel

### DIFF
--- a/samples/integration/ansible-lint.txt
+++ b/samples/integration/ansible-lint.txt
@@ -18,3 +18,4 @@ py36-devel
 deps
 docs
 eco2
+up

--- a/samples/integration/cookiecutter.txt
+++ b/samples/integration/cookiecutter.txt
@@ -21,3 +21,4 @@ py39
 pypy3
 cov-report
 docs2
+up

--- a/samples/integration/podman.txt
+++ b/samples/integration/podman.txt
@@ -9,3 +9,4 @@ install
 package
 package-install
 lint
+up

--- a/src/mk/__main__.py
+++ b/src/mk/__main__.py
@@ -55,13 +55,6 @@ def detect() -> None:
 
 
 @app.command()
-def up() -> None:
-    """Upload current change by creating or updating a CR/PR."""
-    typer.secho("mk up...", fg="yellow")
-    ctx.runner.up()
-
-
-@app.command()
 def commands() -> None:
     """List all commands available."""
     for action in ctx.runner.actions:

--- a/src/mk/exec.py
+++ b/src/mk/exec.py
@@ -1,0 +1,17 @@
+import logging
+import subprocess
+import sys
+
+
+def fail(msg: str, code: int = 1) -> None:
+    logging.error(msg)
+    sys.exit(code)
+
+
+def run(*args) -> None:
+    result = subprocess.run(*args, check=False)
+    if result.returncode != 0:
+        fail(
+            f"Received exit code {result.returncode} from: {' '.join(result.args)}",
+            code=result.returncode,
+        )

--- a/src/mk/runner.py
+++ b/src/mk/runner.py
@@ -9,18 +9,20 @@ from git import Repo
 from git.exc import GitError
 
 from mk.tools import Action
+from mk.tools.git import GitTool
 
 
 class Runner:
     def __init__(self) -> None:
+        self.actions: List[Action] = []
         try:
             self.repo = Repo(".", search_parent_directories=True)
         except GitError:
             logging.fatal("Current version of mk works only within git repos.")
-            sys.exit(1)
+            self.repo = None
+            return
 
         self.root = Path(self.repo.working_dir)
-        self.actions: List[Action] = []
 
         self.pm = pluggy.PluginManager("mk_tools")
         self.pm.load_setuptools_entrypoints("mk_tools")
@@ -36,26 +38,18 @@ class Runner:
         if self.repo.is_dirty():
             logging.warning("Repo is dirty on %s", self.repo.active_branch)
 
+        # expos up command
+        self.actions.append(
+            Action(
+                name="up",
+                description="Upload current change by creating or updating a CR/PR.",
+                tool=GitTool(),
+                runner=self,
+            )
+        )
+
     def info(self) -> None:
         logging.info("Actions identified: %s", self.actions)
-
-    def up(self):
-        if self.repo.is_dirty():
-            sys.exit(2)
-        if (self.root / ".gitreview").is_file():
-            cmd = ["git", "review"]
-        else:
-            if self.repo.active_branch in ["main", "master"]:
-                fail(
-                    "Uploading from default branche is not allowed in order to avoid accidents.", 2
-                )
-            run(["git", "push", "--force-with-lease", "-u", "origin", "HEAD"])
-            # github for the moment
-            # https://github.com/cli/cli/issues/1718
-
-            # --web option is of not use because it happens to soon, confusing github
-            cmd = ["gh", "pr", "create", "--fill"]  # {self.repo.active_branch}
-        run(cmd)
 
 
 def fail(msg: str, code=1) -> None:

--- a/src/mk/tools/__init__.py
+++ b/src/mk/tools/__init__.py
@@ -1,4 +1,8 @@
+import typing
 from typing import Any, List, Optional
+
+if typing.TYPE_CHECKING:
+    from mk.runner import Runner
 
 
 class Action:
@@ -12,6 +16,7 @@ class Action:
         cwd: Optional[str] = None,
         filename: Optional[str] = None,
         args: Optional[List[Any]] = [],
+        runner: Optional["Runner"] = None,
     ) -> None:
         self.name = name
         self.description: str = (description or "...") + f" (from {tool})"
@@ -19,6 +24,7 @@ class Action:
         self.cwd = cwd
         self.filename = filename
         self.args = args
+        self.runner = runner
 
         # Python does not allow writing __doc__ and this is what click uses
         # for storing command names.

--- a/src/mk/tools/git.py
+++ b/src/mk/tools/git.py
@@ -1,0 +1,45 @@
+import logging
+import sys
+from typing import List, Optional
+
+from mk.exec import fail, run
+from mk.tools import Action, Tool
+
+
+class GitTool(Tool):
+    name = "git"
+
+    def __init__(self):
+        super().__init__(self)
+
+    def run(self, action: Optional[Action] = None) -> None:
+        if action and action.name == "up" and action.runner:
+            self.up(runner=action.runner)
+        else:
+            raise NotImplementedError(f"Action {action} is not supported.")
+
+    def is_present(self, path: str) -> bool:
+        return True
+
+    def actions(self) -> List[Action]:
+        actions: List[Action] = []
+        return actions
+
+    def up(self, runner):
+        if not runner.repo or runner.repo.is_dirty():
+            logging.fatal("This action cannot be performed with dirty repos.")
+            sys.exit(2)
+        if (runner.root / ".gitreview").is_file():
+            cmd = ["git", "review"]
+        else:
+            if runner.repo.active_branch in ["main", "master"]:
+                fail(
+                    "Uploading from default branch is not allowed in order to avoid accidents.", 2
+                )
+            run(["git", "push", "--force-with-lease", "-u", "origin", "HEAD"])
+            # github for the moment
+            # https://github.com/cli/cli/issues/1718
+
+            # --web option is of not use because it happens to soon, confusing github
+            cmd = ["gh", "pr", "create", "--fill"]  # {self.repo.active_branch}
+        run(cmd)

--- a/src/mk/tools/git.py
+++ b/src/mk/tools/git.py
@@ -1,5 +1,8 @@
 import logging
+import os
+import re
 import sys
+import subprocess
 from typing import List, Optional
 
 from mk.exec import fail, run
@@ -31,6 +34,7 @@ class GitTool(Tool):
             sys.exit(2)
         if (runner.root / ".gitreview").is_file():
             cmd = ["git", "review"]
+            run(cmd)
         else:
             if runner.repo.active_branch in ["main", "master"]:
                 fail(
@@ -41,5 +45,26 @@ class GitTool(Tool):
             # https://github.com/cli/cli/issues/1718
 
             # --web option is of not use because it happens to soon, confusing github
-            cmd = ["gh", "pr", "create", "--fill"]  # {self.repo.active_branch}
-        run(cmd)
+            # environ={'PAGER': 'cat'}
+            logging.debug("Tryging to detect if there are existing PRs open")
+            os.environ['GITPAGER'] = 'cat'
+            result = subprocess.run(
+                ["gh", "pr", "list", "-S", f"head:{runner.repo.active_branch}"],
+                check=False,
+                stdin=subprocess.DEVNULL,
+                env=os.environ,
+                universal_newlines=True,
+                capture_output=True)
+            if result.returncode == 0:
+                print(result)
+                pr_list = []
+                for line in result.stdout.splitlines():
+                    pr_list.append(line.split('\t')[0])
+                if len(pr_list) == 0:
+                    logging.debug("Existing PR not found, creating one.")
+                    cmd = ["gh", "pr", "create", "--fill"]  # {self.repo.active_branch}
+                    run(cmd, environ={'PAGER': 'cat'})
+                elif len(pr_list) == 1:
+                    logging.debug("PR#%s already exists, no need to update.", pr_list[0])
+                else:
+                    logging.warning("Unable to decide which PR to use when multiple are found: %s", pr_list)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -62,7 +62,7 @@ def test_help() -> None:
 
 
 def test_no_git_repo() -> None:
-    """Ensure failure to run outside git repos."""
+    """Ensure error message is displayed outside git repos."""
     result = run(["mk"], universal_newlines=True, capture_output=True, check=False, cwd="/")
-    assert result.returncode == 1, result
+    assert result.returncode == 0, result
     assert "Current version of mk works only within git repos" in result.stderr


### PR DESCRIPTION
- Disable interpolation when reading tox config (#34)
- Recognize all gnu make configs (#36)
- npm: recognize files in repository root (#37)
- npm: avoid failing when scripts key is missing (#38)
- Update git ignore (#39)
- Add ability to recognize ansible playbooks (#42)
- Add ability to recognize shell scripts under tools (#43)
- Add command to list command and integration tests (#44)
- Move upload command inside a tool
- Avoid attempt to create a pull-request if one exists
