### PR TITLE
Add ability to recognize python packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
     rev: v0.812
     hooks:
       - id: mypy
-        # empy args needed in order to match mypy cli behavior
+        # mypy args needed in order to match mypy cli behavior
         args: []
         entry: mypy src/
         pass_filenames: false
@@ -55,8 +55,8 @@ repos:
           - packaging
           - rich
           - typer
-  - repo: https://github.com/pre-commit/mirrors-pylint
-    rev: v3.0.0a1
+  - repo: https://github.com/pycqa/pylint
+    rev: pylint-3.0.0a1
     hooks:
       - id: pylint
         additional_dependencies:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,16 @@
 #
 #    pip-compile --output-file=requirements.txt setup.cfg
 #
+bleach==3.3.0
+    # via readme-renderer
 blessings==1.7
     # via mk (setup.cfg)
+build==0.3.1.post1
+    # via mk (setup.cfg)
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
 click-help-colors==0.9
     # via mk (setup.cfg)
 click==7.1.2
@@ -17,33 +25,82 @@ colorama==0.4.4
     # via
     #   mk (setup.cfg)
     #   rich
+    #   twine
 commonmark==0.9.1
     # via rich
+docutils==0.17
+    # via readme-renderer
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.14
     # via mk (setup.cfg)
+idna==2.10
+    # via requests
 importlib-metadata==3.10.0
-    # via mk (setup.cfg)
+    # via
+    #   keyring
+    #   mk (setup.cfg)
+    #   twine
+keyring==23.0.1
+    # via twine
+packaging==20.9
+    # via
+    #   bleach
+    #   build
+pep517==0.10.0
+    # via build
+pkginfo==1.7.0
+    # via twine
 pluggy==0.13.1
     # via mk (setup.cfg)
 pygments==2.8.1
     # via
     #   mk (setup.cfg)
+    #   readme-renderer
     #   rich
+pyparsing==2.4.7
+    # via packaging
 pyyaml==5.4.1
     # via mk (setup.cfg)
+readme-renderer==29.0
+    # via twine
+requests-toolbelt==0.9.1
+    # via twine
+requests==2.25.1
+    # via
+    #   requests-toolbelt
+    #   twine
+rfc3986==1.4.0
+    # via twine
 rich==10.0.1
     # via mk (setup.cfg)
 shellingham==1.4.0
     # via mk (setup.cfg)
 six==1.15.0
-    # via blessings
+    # via
+    #   bleach
+    #   blessings
+    #   readme-renderer
 smmap==4.0.0
     # via gitdb
+toml==0.10.2
+    # via
+    #   build
+    #   pep517
+tqdm==4.60.0
+    # via twine
+twine==3.4.1
+    # via mk (setup.cfg)
 typer==0.3.2
     # via mk (setup.cfg)
 typing-extensions==3.7.4.3
     # via rich
+urllib3==1.26.4
+    # via requests
+webencodings==0.5.1
+    # via bleach
 zipp==3.4.1
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/samples/integration/ansible-lint.txt
+++ b/samples/integration/ansible-lint.txt
@@ -1,7 +1,9 @@
+build
 deps
 docs
 eco
 eco2
+install
 lint
 lint2
 packaging
@@ -18,4 +20,5 @@ py39-ansible29
 py39-core
 py39-devel
 test-setup
+uninstall
 up

--- a/samples/integration/cookiecutter.txt
+++ b/samples/integration/cookiecutter.txt
@@ -1,3 +1,4 @@
+build
 clean
 clean-build
 clean-pyc
@@ -6,6 +7,7 @@ cov-report
 coverage
 docs
 docs2
+install
 lint
 lint2
 lint23
@@ -20,5 +22,6 @@ servedocs
 submodules
 test
 test-all
+uninstall
 up
 wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,15 +39,18 @@ zip_safe = False
 install_requires =
     GitPython
     blessings
+    build>=0.3.1.post1  # py_package
     click >= 7.1.2
     click-help-colors
     colorama  # for Windows
     importlib-metadata
+    pip>=21.0.1  # py_package
     pluggy
     pygments
     pyyaml
     rich >= 9.0
     shellingham
+    twine>=3.4.1  # py_package
     typer
 
 [options.packages.find]
@@ -61,6 +64,7 @@ mk_tools =
     git=mk.tools.git:GitTool
     make=mk.tools.make:MakeTool
     npm=mk.tools.npm:NpmTool
+    pypackage=mk.tools.py_package:PyPackageTool
     pre-commit=mk.tools.pre_commit:PreCommitTool
     shell=mk.tools.shell:ShellTool
     tox=mk.tools.tox:ToxTool

--- a/src/mk/tools/py_package.py
+++ b/src/mk/tools/py_package.py
@@ -1,0 +1,54 @@
+import os
+import subprocess
+import sys
+from typing import List, Optional
+
+from mk.tools import Action, Tool
+
+
+class PyPackageTool(Tool):
+    """Expose build, install and uninstall commands for python packages."""
+
+    name = "pip"
+
+    def __init__(self) -> None:
+        super().__init__(self)
+
+    def run(self, action: Optional[Action] = None) -> None:
+        if not action:
+            return
+        if action.name == "build":
+            cmd = [sys.executable, "-m", "build", "--sdist", "--wheel", "--outdir", "dist"]
+            subprocess.run(cmd, check=True)
+            subprocess.run(f"{sys.executable} -m twine check dist/*", shell=True, check=True)
+        elif action.name == "install":
+            cmd = [sys.executable, "-m", "pip", action.name, "-e", "."]
+            subprocess.run(cmd, check=True)
+        elif action.name == "uninstall":
+            pkg_name = subprocess.check_output(
+                [sys.executable, "setup.py", "--name"], universal_newlines=True
+            )
+            cmd = [sys.executable, "-m", "pip", action.name, "-y", pkg_name]
+            subprocess.run(cmd, check=True)
+
+    def is_present(self, path: str) -> bool:
+        for name in ("setup.cfg", "setup.py", "pyproject.toml"):
+            if os.path.isfile(name):
+                return True
+        return False
+
+    def actions(self) -> List[Action]:
+        actions = []
+
+        for name in ("install", "uninstall"):
+            description = f"Use pip to {name} current package"
+            actions.append(Action(name=name, tool=self, description=description))
+        actions.append(
+            Action(
+                name="build",
+                tool=self,
+                description="Use python build to produce sdist and wheel, followed by twine check",
+            )
+        )
+
+        return actions

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,8 +6,16 @@
 #
 attrs==20.3.0
     # via pytest
+bleach==3.3.0
+    # via readme-renderer
 blessings==1.7
     # via mk (setup.cfg)
+build==0.3.1.post1
+    # via mk (setup.cfg)
+certifi==2020.12.5
+    # via requests
+chardet==4.0.0
+    # via requests
 click-help-colors==0.9
     # via mk (setup.cfg)
 click==7.1.2
@@ -19,20 +27,37 @@ colorama==0.4.4
     # via
     #   mk (setup.cfg)
     #   rich
+    #   twine
 commonmark==0.9.1
     # via rich
+docutils==0.17
+    # via readme-renderer
 gitdb==4.0.7
     # via gitpython
 gitpython==3.1.14
     # via mk (setup.cfg)
+idna==2.10
+    # via requests
 importlib-metadata==3.10.0
-    # via mk (setup.cfg)
+    # via
+    #   keyring
+    #   mk (setup.cfg)
+    #   twine
 iniconfig==1.1.1
     # via pytest
+keyring==23.0.1
+    # via twine
 more-itertools==8.7.0
     # via pytest-plus
 packaging==20.9
-    # via pytest
+    # via
+    #   bleach
+    #   build
+    #   pytest
+pep517==0.10.0
+    # via build
+pkginfo==1.7.0
+    # via twine
 pluggy==0.13.1
     # via
     #   mk (setup.cfg)
@@ -42,6 +67,7 @@ py==1.10.0
 pygments==2.8.1
     # via
     #   mk (setup.cfg)
+    #   readme-renderer
     #   rich
 pyparsing==2.4.7
     # via packaging
@@ -53,19 +79,46 @@ pytest==6.2.2
     #   pytest-plus
 pyyaml==5.4.1
     # via mk (setup.cfg)
+readme-renderer==29.0
+    # via twine
+requests-toolbelt==0.9.1
+    # via twine
+requests==2.25.1
+    # via
+    #   requests-toolbelt
+    #   twine
+rfc3986==1.4.0
+    # via twine
 rich==10.0.1
     # via mk (setup.cfg)
 shellingham==1.4.0
     # via mk (setup.cfg)
 six==1.15.0
-    # via blessings
+    # via
+    #   bleach
+    #   blessings
+    #   readme-renderer
 smmap==4.0.0
     # via gitdb
 toml==0.10.2
-    # via pytest
+    # via
+    #   build
+    #   pep517
+    #   pytest
+tqdm==4.60.0
+    # via twine
+twine==3.4.1
+    # via mk (setup.cfg)
 typer==0.3.2
     # via mk (setup.cfg)
 typing-extensions==3.7.4.3
     # via rich
+urllib3==1.26.4
+    # via requests
+webencodings==0.5.1
+    # via bleach
 zipp==3.4.1
     # via importlib-metadata
+
+# The following packages are considered to be unsafe in a requirements file:
+# pip

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -1,4 +1,5 @@
 import os
+import re
 from subprocess import run
 
 import pytest
@@ -30,7 +31,7 @@ def test_show_completion_script(shell, expected) -> None:
 @pytest.mark.parametrize(
     "shell,expected",
     (
-        pytest.param("zsh", "_arguments", id="zsh"),
+        pytest.param("zsh", '^_arguments.*\n"commands":', id="zsh"),
         pytest.param("bash", "commands\n", id="bash"),
     ),
 )
@@ -50,7 +51,7 @@ def test_show_completion_data(shell, expected) -> None:
     # working, disabling return code testing until we know why.
     # assert result.returncode == 0, result
     # very important as we could easily break it by sending data to stdout
-    assert result.stdout.startswith(expected)
+    assert re.search(expected, result.stdout, flags=re.MULTILINE)
 
 
 def test_help() -> None:


### PR DESCRIPTION
Expose build, install and uninstall commands for python packages.
Current implementation relies on pip, build and twine packages.

Note that the current logic is not fool-proof and is known to have some side effects. For example https://github.com/python/cpython project has a `setup.py` file, which even expose a package named `Python`, which obviously cannot be uninstalled by pip. Still, because mk assume any python package can be installed and uninstall with pip, it would add a command that is broken.

As I am not yet sure how to address this, I will defer making a decision for later.