### PR TITLE
Refactor subprocess execution

### DIFF
--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install system dependencies
         run: |
           sudo apt-get update \
-          && sudo apt-get install -y libvirt-dev
+          && sudo apt-get install -y libvirt-dev zsh
       - name: Find python version
         id: py_ver
         shell: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
           - importlib-metadata
           - packaging
           - rich
+          - subprocess-tee
           - typer
   - repo: https://github.com/pycqa/pylint
     rev: pylint-3.0.0a1
@@ -65,4 +66,5 @@ repos:
           - importlib-metadata
           - pytest
           - rich
+          - subprocess-tee
           - typer

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,8 @@ six==1.15.0
     #   readme-renderer
 smmap==4.0.0
     # via gitdb
+subprocess-tee==0.3.1
+    # via mk (setup.cfg)
 toml==0.10.2
     # via
     #   build

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ install_requires =
     pyyaml
     rich >= 9.0
     shellingham
+    subprocess-tee >= 0.3.1
     twine>=3.4.1  # py_package
     typer
 

--- a/src/mk/__main__.py
+++ b/src/mk/__main__.py
@@ -21,7 +21,7 @@ if "_MK_COMPLETE" in os.environ:
     handlers = [logging.NullHandler()]
 else:
     level = logging.DEBUG
-    handlers = [RichHandler(console=console_err, show_time=False, show_path=False, markup=True)]
+    handlers = [RichHandler(console=console_err, show_time=False, show_path=False, markup=False)]
 
 logging.basicConfig(
     level=logging.INFO,

--- a/src/mk/exec.py
+++ b/src/mk/exec.py
@@ -2,17 +2,47 @@ import logging
 import subprocess
 import sys
 
+import subprocess_tee
+
 
 def fail(msg: str, code: int = 1) -> None:
     logging.error(msg)
     sys.exit(code)
 
 
-def run(*args) -> subprocess.CompletedProcess:
-    result = subprocess.run(*args, capture_output=True, check=False, universal_newlines=True)  # type: ignore
-    if result.returncode != 0:
-        fail(
-            f"Received exit code {result.returncode} from: {' '.join(result.args)}\n{result.stdout}\n{result.stderr}",
-            code=result.returncode,
-        )
+def run(args, *, check=False, cwd=None, tee=False) -> subprocess.CompletedProcess:
+    if isinstance(args, str):
+        cmd = args
+        shell = True
+    else:
+        cmd = " ".join(args)
+        shell = False
+    logging.info("Executing: %s", cmd)
+    result = subprocess_tee.run(
+        args,
+        capture_output=True,
+        check=check,
+        shell=shell,
+        universal_newlines=True,
+        cwd=cwd,
+        tee=tee,
+    )
     return result
+
+
+def run_or_raise(*args, cwd=None, tee=False) -> subprocess.CompletedProcess:
+    return run(*args, check=True, cwd=cwd, tee=tee)
+
+
+def run_or_fail(*args, cwd=None, tee=False) -> subprocess.CompletedProcess:
+    try:
+        return run(*args, check=True, cwd=cwd, tee=tee)
+    except subprocess.CalledProcessError as exc:
+        msg = f"Received exit code {exc.returncode} from: {args}"
+        if not tee:
+            msg += f"\n{exc.stdout}\n{exc.stderr}"
+        fail(
+            msg,
+            code=exc.returncode,
+        )
+        raise

--- a/src/mk/runner.py
+++ b/src/mk/runner.py
@@ -1,6 +1,4 @@
 import logging
-import subprocess
-import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, List
 
@@ -42,17 +40,3 @@ class Runner:
 
     def info(self) -> None:
         logging.info("Actions identified: %s", self.actions)
-
-
-def fail(msg: str, code=1) -> None:
-    logging.error(msg)
-    sys.exit(code)
-
-
-def run(*args) -> None:
-    result = subprocess.run(*args, check=False)
-    if result.returncode != 0:
-        fail(
-            f"Received exit code {result.returncode} from: {' '.join(result.args)}",
-            code=result.returncode,
-        )

--- a/src/mk/tools/ansible.py
+++ b/src/mk/tools/ansible.py
@@ -1,8 +1,8 @@
 import glob
 import os
-import subprocess
 from typing import List, Optional
 
+from mk.exec import run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -11,7 +11,7 @@ class AnsibleTool(Tool):
 
     def run(self, action: Optional[Action] = None):
         if action and action.filename:
-            subprocess.run(["ansible-playbook", action.filename], check=True)
+            run_or_fail(["ansible-playbook", action.filename], tee=True)
 
     def is_present(self, path: str) -> bool:
         if os.path.isdir(os.path.join(path, "playbooks")):

--- a/src/mk/tools/make.py
+++ b/src/mk/tools/make.py
@@ -1,8 +1,8 @@
 import os
 import re
-import subprocess
 from typing import List, Optional
 
+from mk.exec import run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -17,7 +17,7 @@ class MakeTool(Tool):
         cmd = ["make"]
         if action:
             cmd.append(action.name)
-        subprocess.run(cmd, check=True)
+        run_or_fail(cmd, tee=True)
 
     def is_present(self, path: str) -> bool:
         for name in ["Makefile", "makefile", "GNUmakefile"]:

--- a/src/mk/tools/npm.py
+++ b/src/mk/tools/npm.py
@@ -1,7 +1,7 @@
 import json
-import subprocess
 from typing import List
 
+from mk.exec import run, run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -10,13 +10,8 @@ class NpmTool(Tool):
 
     def __init__(self, path=".") -> None:
         super().__init__(path=path)
-        cmd = ("git", "ls-files", "**/package.json", "package.json")
-        result = subprocess.run(
-            cmd,
-            stdout=subprocess.PIPE,
-            universal_newlines=True,
-            check=False,
-        )
+        cmd = ["git", "ls-files", "**/package.json", "package.json"]
+        result = run(cmd)
         if result.returncode != 0 or not result.stdout:
             self.present = False
             return
@@ -54,4 +49,4 @@ class NpmTool(Tool):
         else:
             cmd = ["npm", "run", action.name]
             cwd = action.cwd
-        subprocess.run(cmd, check=True, cwd=cwd)
+        run_or_fail(cmd, cwd=cwd, tee=True)

--- a/src/mk/tools/pre_commit.py
+++ b/src/mk/tools/pre_commit.py
@@ -1,7 +1,7 @@
 import os
-import subprocess
 from typing import List, Optional
 
+from mk.exec import run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -9,7 +9,7 @@ class PreCommitTool(Tool):
     name = "pre-commit"
 
     def run(self, action: Optional[Action] = None):
-        subprocess.run(["pre-commit", "run", "-a"], check=True)
+        run_or_fail(["pre-commit", "run", "-a"], tee=True)
 
     def is_present(self, path: str) -> bool:
         if os.path.isfile(os.path.join(path, ".pre-commit-config.yaml")):

--- a/src/mk/tools/py_package.py
+++ b/src/mk/tools/py_package.py
@@ -1,8 +1,8 @@
 import os
-import subprocess
 import sys
 from typing import List, Optional
 
+from mk.exec import run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -19,17 +19,15 @@ class PyPackageTool(Tool):
             return
         if action.name == "build":
             cmd = [sys.executable, "-m", "build", "--sdist", "--wheel", "--outdir", "dist"]
-            subprocess.run(cmd, check=True)
-            subprocess.run(f"{sys.executable} -m twine check dist/*", shell=True, check=True)
+            run_or_fail(cmd, tee=True)
+            run_or_fail(f"{sys.executable} -m twine check dist/*", tee=True)
         elif action.name == "install":
             cmd = [sys.executable, "-m", "pip", action.name, "-e", "."]
-            subprocess.run(cmd, check=True)
+            run_or_fail(cmd, tee=True)
         elif action.name == "uninstall":
-            pkg_name = subprocess.check_output(
-                [sys.executable, "setup.py", "--name"], universal_newlines=True
-            )
+            pkg_name = run_or_fail([sys.executable, "setup.py", "--name"], tee=False).stdout
             cmd = [sys.executable, "-m", "pip", action.name, "-y", pkg_name]
-            subprocess.run(cmd, check=True)
+            run_or_fail(cmd, tee=True)
 
     def is_present(self, path: str) -> bool:
         for name in ("setup.cfg", "setup.py", "pyproject.toml"):

--- a/src/mk/tools/shell.py
+++ b/src/mk/tools/shell.py
@@ -1,8 +1,8 @@
 import glob
 import os
-import subprocess
 from typing import List, Optional
 
+from mk.exec import run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -11,7 +11,7 @@ class ShellTool(Tool):
 
     def run(self, action: Optional[Action] = None) -> None:
         if action and action.filename:
-            subprocess.run([action.filename], check=True)
+            run_or_fail(action.filename, tee=True)
 
     def is_present(self, path: str) -> bool:
         return True

--- a/src/mk/tools/tox.py
+++ b/src/mk/tools/tox.py
@@ -1,8 +1,8 @@
 import os
-import subprocess
 from configparser import ConfigParser
 from typing import List, Optional
 
+from mk.exec import run_or_fail
 from mk.tools import Action, Tool
 
 
@@ -18,7 +18,7 @@ class ToxTool(Tool):
         # -a is not supported by tox4!
         actions: List[Action] = []
         cp = ConfigParser(strict=False, interpolation=None)
-        tox_cfg = subprocess.check_output(["tox", "--showconfig"], universal_newlines=True)
+        tox_cfg = run_or_fail(["tox", "--showconfig"]).stdout
         cp.read_string(tox_cfg)
         for section in cp.sections():
             if section.startswith("testenv:"):
@@ -41,4 +41,4 @@ class ToxTool(Tool):
             cmd = ["tox"]
         else:
             cmd = ["tox", "-e", action.name]
-        subprocess.run(cmd, check=True)
+        run_or_fail(cmd, tee=True)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -100,6 +100,8 @@ six==1.15.0
     #   readme-renderer
 smmap==4.0.0
     # via gitdb
+subprocess-tee==0.3.1
+    # via mk (setup.cfg)
 toml==0.10.2
     # via
     #   build


### PR DESCRIPTION
Assure we use only our own wrappers when running subprocesses in
order to better control how we call them and be able to easily
adjust the logging levels.